### PR TITLE
fix: Addressing the issue of delayed network updates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+networkmanager-qt6 (6.0.0-0deepin1) unstable; urgency=medium
+
+  * Addressing the issue of delayed network updates
+
+ -- caixiangrong <caixiangrong@uniontech.com>  Thu, 10 Apr 2025 13:22:20 +0800
+
 networkmanager-qt6 (6.0.0-0deepin) unstable; urgency=medium
 
   * Init package 

--- a/debian/patches/0003-deepin-wirelessnetwork-update.patch
+++ b/debian/patches/0003-deepin-wirelessnetwork-update.patch
@@ -1,0 +1,27 @@
+Index: networkmanager-qt6/src/wirelessnetwork.cpp
+===================================================================
+--- networkmanager-qt6.orig/src/wirelessnetwork.cpp
++++ networkmanager-qt6/src/wirelessnetwork.cpp
+@@ -65,18 +65,10 @@ void NetworkManager::WirelessNetworkPriv
+         return;
+     }
+ 
+-    NetworkManager::AccessPoint::Ptr activeAp = wirelessNetworkInterface->activeAccessPoint();
+-    if (activeAp && activeAp->ssid() == ssid) {
+-        // If the network has an active access point, use it as the referenceAp
+-        selectedStrength = activeAp->signalStrength();
+-        selectedAp = activeAp;
+-    } else {
+-        // Otherwise, choose the access point with the strongest signal
+-        for (const NetworkManager::AccessPoint::Ptr &iface : std::as_const(aps)) {
+-            if (selectedStrength <= iface->signalStrength()) {
+-                selectedStrength = iface->signalStrength();
+-                selectedAp = iface;
+-            }
++    for (const NetworkManager::AccessPoint::Ptr &iface : std::as_const(aps)) {
++        if (selectedStrength <= iface->signalStrength()) {
++            selectedStrength = iface->signalStrength();
++            selectedAp = iface;
+         }
+     }
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 0001-deepin-accesspoints.patch
 #0002-deepin-device-interface.patch
+0003-deepin-wirelessnetwork-update.patch


### PR DESCRIPTION
When connecting a hidden network, when the hidden network is discovered, the newly discovered hidden network will not be updated as it is currently being connected

pms: BUG-286927